### PR TITLE
Add translation disclaimer to ru articles

### DIFF
--- a/src/components/TranslationDisclaimer.astro
+++ b/src/components/TranslationDisclaimer.astro
@@ -1,0 +1,19 @@
+---
+import { getTextLocalized, translations } from "../languages";
+
+type Props = {
+    lang: string;
+};
+
+const { lang } = Astro.props;
+---
+
+<div class="admonition admonition-warning">
+    <div class="admonition-heading">
+        <span class="admonition-title">{getTextLocalized(translations.TranslationDisclaimer.title, lang)}</span>
+    </div>
+    <div class="admonition-content">
+        <p>{getTextLocalized(translations.TranslationDisclaimer.firstLine, lang)}</p>
+        <p>{getTextLocalized(translations.TranslationDisclaimer.secondLine, lang)}</p>
+    </div>
+</div>

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -1,98 +1,116 @@
 import path from "node:path";
-import { KNOWN_LANGUAGES, KNOWN_LANGUAGE_CODES, SITE } from "./consts";
-export { KNOWN_LANGUAGES, KNOWN_LANGUAGE_CODES };
+import {KNOWN_LANGUAGES, KNOWN_LANGUAGE_CODES, SITE} from "./consts";
+
+export {KNOWN_LANGUAGES, KNOWN_LANGUAGE_CODES};
 
 export type LText = {
-  [Key in (typeof KNOWN_LANGUAGE_CODES)[number]]?: string;
+    [Key in (typeof KNOWN_LANGUAGE_CODES)[number]]?: string;
 } & { en: string };
 
 export const langPathRegex = /\/([a-z]{2}-?[A-Z]{0,2})\//;
 
 export function getLanguageFromURL(pathname: string) {
-  const langCodeMatch = pathname.match(langPathRegex);
-  const langCode = langCodeMatch ? langCodeMatch[1] : "en";
-  return langCode as (typeof KNOWN_LANGUAGE_CODES)[number];
+    const langCodeMatch = pathname.match(langPathRegex);
+    const langCode = langCodeMatch ? langCodeMatch[1] : "en";
+    return langCode as (typeof KNOWN_LANGUAGE_CODES)[number];
 }
 
 export function getPathParamsFromId(pathname: string) {
-  const strippedPath = pathname.startsWith("/") ? pathname.slice(1) : pathname;
-  const ext = path.extname(strippedPath);
-  const parts = strippedPath.replace(ext, "").split("/");
-  const lang = parts.shift()! || SITE.defaultLanguage;
-  const slug = parts.join("/") || "/";
-  return { lang, slug };
+    const strippedPath = pathname.startsWith("/") ? pathname.slice(1) : pathname;
+    const ext = path.extname(strippedPath);
+    const parts = strippedPath.replace(ext, "").split("/");
+    const lang = parts.shift()! || SITE.defaultLanguage;
+    const slug = parts.join("/") || "/";
+    return {lang, slug};
 }
 
 export function getTextLocalized(item: { text: LText }, lang: string): string {
-  if (lang in item.text) {
-    return item.text[lang as "en" | "ru"]!;
-  }
-  return item.text.en;
+    if (lang in item.text) {
+        return item.text[lang as "en" | "ru"]!;
+    }
+    return item.text.en;
 }
 
 export function createLink(item: { text: LText; link: string }, lang: string): string {
-  if (item.link.startsWith("/")) {
-    return `/${lang}${item.link}`;
-  }
-  return item.link;
+    if (item.link.startsWith("/")) {
+        return `/${lang}${item.link}`;
+    }
+    return item.link;
 }
 
-export function createChangeLangLinks({ slug }: { slug: string }) {
-  return Object.entries(KNOWN_LANGUAGES).map(([name, code]) => ({
-    text: { en: name },
-    link: slug === "/" ? `/${code}` : `/${code}/${slug}`,
-  }));
+export function createChangeLangLinks({slug}: { slug: string }) {
+    return Object.entries(KNOWN_LANGUAGES).map(([name, code]) => ({
+        text: {en: name},
+        link: slug === "/" ? `/${code}` : `/${code}/${slug}`,
+    }));
 }
 
 export const translations = {
-  docs: { text: { en: "Docs", ru: "Меню" } },
-  Documentation: { text: { en: "Documentation", ru: "Документация" } },
-  ThisPageIsNotTranslatedYet: {
-    text: {
-      en: "This page is not translated yet",
-      ru: "Этот страница еще не переведена",
+    docs: {text: {en: "Docs", ru: "Меню"}},
+    Documentation: {text: {en: "Documentation", ru: "Документация"}},
+    ThisPageIsNotTranslatedYet: {
+        text: {
+            en: "This page is not translated yet",
+            ru: "Этот страница еще не переведена",
+        },
     },
-  },
-  PleaseOpenPRWithTranslations: {
-    text: {
-      en: "To add new translation open Pull Request",
-      ru: "Чтобы добавить перевод, откройте Pull Request",
+    TranslationDisclaimer: {
+        title: {
+            text: {
+                ru: 'Перевод поддерживается сообществом'
+            }
+        },
+        firstLine: {
+            text: {
+                ru: 'Документация на английском языке - самая актуальная, поскольку ее пишет и обновляет команда effector. Перевод документации на другие языки осуществляется сообществом по мере наличия сил и желания.'
+            }
+        },
+        secondLine: {
+            text: {
+                ru: 'Помните, что переведенные статьи могут быть неактуальными, поэтому для получения наиболее точной и актуальной информации рекомендуем использовать оригинальную англоязычную версию документации.'
+            }
+        }
     },
-  },
-  usingThisLink: {
-    text: {
-      en: "using this link",
-      ru: "по этой ссылке",
+    PleaseOpenPRWithTranslations: {
+        text: {
+            en: "To add new translation open Pull Request",
+            ru: "Чтобы добавить перевод, откройте Pull Request",
+        },
     },
-  },
-  ShowingContentForDefaultLanguage: {
-    text: {
-      en: "Showing content for default language",
-      ru: "Отображается содержимое для языка по умолчанию",
+    usingThisLink: {
+        text: {
+            en: "using this link",
+            ru: "по этой ссылке",
+        },
     },
-  },
-  OnThisPage: {
-    text: {
-      en: "On this page",
-      ru: "Оглавление",
+    ShowingContentForDefaultLanguage: {
+        text: {
+            en: "Showing content for default language",
+            ru: "Отображается содержимое для языка по умолчанию",
+        },
     },
-  },
-  EditThisPage: {
-    text: {
-      en: "Edit this page",
-      ru: "Внести правки",
+    OnThisPage: {
+        text: {
+            en: "On this page",
+            ru: "Оглавление",
+        },
     },
-  },
-  JoinOurCommunity: {
-    text: {
-      en: "Join our community",
-      ru: "Войти в чат",
+    EditThisPage: {
+        text: {
+            en: "Edit this page",
+            ru: "Внести правки",
+        },
     },
-  },
-  More: {
-    text: {
-      en: "More",
-      ru: "Дополнительно",
+    JoinOurCommunity: {
+        text: {
+            en: "Join our community",
+            ru: "Войти в чат",
+        },
     },
-  },
+    More: {
+        text: {
+            en: "More",
+            ru: "Дополнительно",
+        },
+    },
 };

--- a/src/pages/[lang]/[...slug].astro
+++ b/src/pages/[lang]/[...slug].astro
@@ -8,6 +8,7 @@ import { SITE } from "../../consts";
 
 import MainLayout from "../../layouts/MainLayout.astro";
 import NotTranslatedYet from "../../components/NotTranslatedYet.astro";
+import TranslationDisclaimer from "../../components/TranslationDisclaimer.astro";
 
 export async function getStaticPaths() {
   const { sourceSlugs, docs } = await getTranslatedDocsIndex();
@@ -60,4 +61,5 @@ const postData = (post ?? defaultLanguagePost).data;
 >
   {!post ? <NotTranslatedYet lang={lang!} /> : null}
   <Content />
+  {lang !== SITE.defaultLanguage ? <TranslationDisclaimer lang={lang} /> : null}
 </MainLayout>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -494,6 +494,10 @@ h2.heading {
   color: var(--admonition-text);
 }
 
+.admonition-content p + p {
+  margin-top: 1em;
+}
+
 .admonition-tip {
   --admonition-bg: var(--theme-admonition-tip-bg);
   --admonition-border: var(--theme-admonition-tip-border);


### PR DESCRIPTION
This MR adds `TranslationDisclaimer` component that appears on our `ru` documentation pages. 

This component aims to provide our Russian-speaking users with a clear and concise message about the accuracy of the translated documentation. By displaying this disclaimer message on our documentation pages, we hope to reduce confusion and ensure our users can access the most up-to-date and accurate information.

Fixes EFX-120